### PR TITLE
Settings fix for version number upgrade to 3.53.30

### DIFF
--- a/settings.template
+++ b/settings.template
@@ -21,7 +21,7 @@
 : ${DOCKER_REPO:="angelnu/ccu"}
 
 #CCU version to build
-: ${CCU_VERSION:="3.51.6"}
+: ${CCU_VERSION:="3.53.30"}
 MAYOR_CCU_VERSION=${CCU_VERSION%%.*}
 
 #Docker TAG for the DOCKER_ID - this is the version to download


### PR DESCRIPTION
In my previous PR #44 I missed to update the version number in the `settings.template`. As I tried to update my setup today I could not find the image on the docker-hub, because the docker-build process uses the version number from the settings. This PR addresses that.